### PR TITLE
Adjustments on Dockerfiles.

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -3,6 +3,8 @@ LABEL maintainer "Yuki Kikuchi <bclswl0827@yahoo.co.jp>"
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Tokyo
 
+ADD entrypoint.sh /opt/entrypoint.sh
+
 RUN sed -e "s/security.debian.org/mirrors.bfsu.edu.cn/g" \
         -e "s/deb.debian.org/mirrors.bfsu.edu.cn/g" \
         -i /etc/apt/sources.list \
@@ -20,4 +22,4 @@ RUN sed -e "s/security.debian.org/mirrors.bfsu.edu.cn/g" \
     && crontab /tmp/crontab \
     && rm -rf /tmp/crontab /var/lib/apt/lists/*
 
-CMD ["/usr/sbin/cron", "-l", "2", "-f"]
+ENTRYPOINT ["sh", "-c", "/opt/entrypoint.sh"]

--- a/admin/entrypoint.sh
+++ b/admin/entrypoint.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# Main process
+/usr/sbin/cron -l 2 -f

--- a/flydog-sdr/Dockerfile
+++ b/flydog-sdr/Dockerfile
@@ -1,9 +1,10 @@
 FROM debian:buster-slim
 LABEL maintainer "Yuki Kikuchi <bclswl0827@yahoo.co.jp>"
 ARG DEBIAN_FRONTEND=noninteractive
-ENV GIT_URL="github.com" \
-    BRANCH=master \
-    REPO=FlyDog_SDR_GPS
+ENV GIT_BRANCH="master" \
+    GIT_HOST="github.com" \
+    GIT_USER="flydog-sdr" \
+    REPO_NANE="FlyDog_SDR_GPS"
 
 ADD entrypoint.sh /opt/entrypoint.sh
 
@@ -14,15 +15,15 @@ RUN sed -e "s/security.debian.org/mirrors.bfsu.edu.cn/g" \
     && apt-get install --no-install-recommends -y ca-certificates curl file git iptables make rsync upx-ucl \
     && curl -o /tmp/wiringpi.deb https://project-downloads.drogon.net/wiringpi-latest.deb \
     && dpkg -i /tmp/wiringpi.deb \
-    && git clone -b ${BRANCH} https://${GIT_URL}/flydog-sdr/${REPO} /root/${REPO} \
-    && cd /root/${REPO} \
+    && git clone -b ${GIT_BRANCH} https://${GIT_HOST}/${GIT_USER}/${REPO_NANE} /root/${REPO_NANE} \
+    && cd /root/${REPO_NANE} \
     && make \
     && make install \
     && upx --lzma /usr/local/bin/kiwid \
     && echo 1 > /root/kiwi.config/_UPDATE \
-    && cat /root/${REPO}/Makefile | head -2 | cut -d " " -f3 | tr -d "\n" > /root/kiwi.config/_VERSION \
+    && cat /root/${REPO_NANE}/Makefile | head -2 | cut -d " " -f3 | tr -d "\n" > /root/kiwi.config/_VERSION \
     && apt-get autoremove --purge -y clang-7 git iptables make rsync upx-ucl \
-    && rm -rf /root/${REPO}/* \
+    && rm -rf /root/${REPO_NANE}/* \
               /root/build/*.bin \
               /tmp/wiringpi.deb \
               /var/lib/apt/lists/* \

--- a/flydog-sdr/entrypoint.sh
+++ b/flydog-sdr/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Bind IP address of p.sdrotg.com
 echo "1.0.0.1 p.sdrotg.com" >> /etc/hosts
 


### PR DESCRIPTION
1. Use `ENTRYPOINT` instead of `CMD` to start `cron` in `admin` container.
2. Modify `flydog-sdr` container's ENVs to make them more reasonable.
3. Use `#!/bin/sh` at startup.